### PR TITLE
Add config option to disable end portal effect on tanks and chests. And a third for the size of ender tanks

### DIFF
--- a/src/codechicken/enderstorage/EnderStorage.java
+++ b/src/codechicken/enderstorage/EnderStorage.java
@@ -40,7 +40,10 @@ public class EnderStorage
     public static boolean disableVanillaEnderChest;
     public static boolean removeVanillaRecipe;
     public static boolean anarchyMode;
-
+    public static boolean disableFXChest;
+    public static boolean disableFXTank;
+    public static int enderTankSize;
+    
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
         config = new ConfigFile(new File(CommonUtils.getMinecraftDir() + "/config", "EnderStorage.cfg")).setComment("EnderStorage Configuration File\nDeleting any element will restore it to it's default value\nBlock ID's will be automatically generated the first time it's run");
@@ -54,7 +57,10 @@ public class EnderStorage
         disableVanillaEnderChest = config.getTag("disable-vanilla").setComment("Set to true to make the vanilla enderchest unplaceable.").getBooleanValue(true);
         removeVanillaRecipe = config.getTag("disable-vanilla_recipe").setComment("Set to true to make the vanilla enderchest uncraftable.").getBooleanValue(false);
         anarchyMode = config.getTag("anarchy-mode").setComment("Causes chests to lose personal settings and drop the diamond on break").getBooleanValue(false);
-
+        disableFXChest = config.getTag("disableFXChest").setComment("Disable the end portal effect in ES ender chests. May help with FPS (not TPS!) problems.").getBooleanValue(false);
+        disableFXTank = config.getTag("disableFXTank").setComment("Disable the end portal effect in ender tanks. May help with FPS (not TPS!) problems.").getBooleanValue(false);
+        enderTankSize = config.getTag("enderTankSize").setComment("Set the size of ender tanks in buckets (x1000)").getIntValue(256);
+        
         EnderStorageManager.loadConfig(config);
         EnderStorageManager.registerPlugin(new EnderItemStoragePlugin());
         EnderStorageManager.registerPlugin(new EnderLiquidStoragePlugin());

--- a/src/codechicken/enderstorage/storage/item/EnderChestRenderer.java
+++ b/src/codechicken/enderstorage/storage/item/EnderChestRenderer.java
@@ -4,6 +4,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import codechicken.core.ClientUtils;
@@ -12,6 +13,7 @@ import codechicken.lib.render.CCRenderState;
 import codechicken.lib.vec.Matrix4;
 import codechicken.lib.vec.Rotation;
 import codechicken.lib.vec.Vector3;
+import codechicken.enderstorage.EnderStorage;
 import codechicken.enderstorage.api.EnderStorageManager;
 import codechicken.enderstorage.common.RenderCustomEndPortal;
 import codechicken.enderstorage.internal.EnderStorageClientProxy;
@@ -23,8 +25,10 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
     }
 
     public static void renderChest(int rotation, int freq, boolean owned, double x, double y, double z, int offset, float lidAngle) {
-        TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
-        renderEndPortal.render(x, y, z, 0, info.field_147560_j, info.field_147560_j, info.field_147561_k, info.field_147553_e);
+    	if (!EnderStorage.disableFXChest) {
+    		TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
+    		renderEndPortal.render(x, y, z, 0, info.field_147560_j, info.field_147560_j, info.field_147561_k, info.field_147553_e);
+    	}
         GL11.glColor4f(1, 1, 1, 1);
 
         CCRenderState.changeTexture("enderstorage:textures/enderchest.png");

--- a/src/codechicken/enderstorage/storage/liquid/EnderLiquidStorage.java
+++ b/src/codechicken/enderstorage/storage/liquid/EnderLiquidStorage.java
@@ -2,6 +2,7 @@ package codechicken.enderstorage.storage.liquid;
 
 import codechicken.core.fluid.ExtendedFluidTank;
 import codechicken.core.fluid.FluidUtils;
+import codechicken.enderstorage.EnderStorage;
 import codechicken.enderstorage.api.AbstractEnderStorage;
 import codechicken.enderstorage.api.EnderStorageManager;
 import net.minecraft.nbt.NBTTagCompound;
@@ -13,8 +14,8 @@ import net.minecraftforge.fluids.FluidStack;
 
 public class EnderLiquidStorage extends AbstractEnderStorage implements IFluidHandler
 {
-    public static final int CAPACITY = 256 * FluidUtils.B;
-
+    public static final int CAPACITY = EnderStorage.enderTankSize * FluidUtils.B;
+    
     private class Tank extends ExtendedFluidTank
     {
         public Tank(int capacity) {

--- a/src/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -22,6 +22,7 @@ import codechicken.lib.vec.Transformation;
 import codechicken.lib.vec.Translation;
 import codechicken.lib.vec.Vector3;
 import codechicken.lib.vec.SwapYZ;
+import codechicken.enderstorage.EnderStorage;
 import codechicken.enderstorage.api.EnderStorageManager;
 import codechicken.enderstorage.common.RenderCustomEndPortal;
 import codechicken.enderstorage.common.RenderEnderStorage;
@@ -81,8 +82,10 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer
     
     public static void renderTank(int rotation, float valve, int freq, boolean owned, double x, double y, double z, int offset)
     {
-        TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
-        renderEndPortal.render(x, y, z, 0, info.field_147560_j, info.field_147560_j, info.field_147561_k, info.field_147553_e);
+    	if (!EnderStorage.disableFXTank) {
+    		TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
+    		renderEndPortal.render(x, y, z, 0, info.field_147560_j, info.field_147560_j, info.field_147561_k, info.field_147553_e);
+    	}
         GL11.glColor4f(1, 1, 1, 1);
         
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
@@ -131,6 +134,6 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer
         RenderUtils.renderFluidCuboid(liquid, 
                 new Cuboid6(0.22, 0.12, 0.22, 0.78, 0.121+0.63, 0.78)
                     .add(new Vector3(x, y, z)), 
-                liquid.amount/(256D*FluidUtils.B), 0.75);
+                liquid.amount/((double)EnderStorage.enderTankSize*FluidUtils.B), 0.75);
     }
 }


### PR DESCRIPTION
See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/6925
No idea if this will help though

and https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7144
You can change it if you want a different amount. No guarantees it won't crash if you make it smaller than what's currently in the tank though.