### PR TITLE
Optimize performance when rendering ender tanks / chests

### DIFF
--- a/src/main/java/codechicken/enderstorage/api/EnderStorageManager.java
+++ b/src/main/java/codechicken/enderstorage/api/EnderStorageManager.java
@@ -51,7 +51,7 @@ public class EnderStorageManager {
     private static EnderStorageManager serverManager;
     private static EnderStorageManager clientManager;
     private static ConfigFile config;
-    private static HashMap<String, EnderStoragePlugin> plugins = new HashMap<String, EnderStoragePlugin>();
+    private static HashMap<String, EnderStoragePlugin> plugins = new HashMap<>();
 
     private Map<String, AbstractEnderStorage> storageMap;
     private Map<String, List<AbstractEnderStorage>> storageList;
@@ -66,11 +66,11 @@ public class EnderStorageManager {
     public EnderStorageManager(boolean client) {
         this.client = client;
 
-        storageMap = Collections.synchronizedMap(new HashMap<String, AbstractEnderStorage>());
-        storageList = Collections.synchronizedMap(new HashMap<String, List<AbstractEnderStorage>>());
-        dirtyStorage = Collections.synchronizedList(new LinkedList<AbstractEnderStorage>());
+        storageMap = Collections.synchronizedMap(new HashMap<>());
+        storageList = Collections.synchronizedMap(new HashMap<>());
+        dirtyStorage = Collections.synchronizedList(new LinkedList<>());
 
-        for (String key : plugins.keySet()) storageList.put(key, new ArrayList<AbstractEnderStorage>());
+        for (String key : plugins.keySet()) storageList.put(key, new ArrayList<>());
 
         if (!client) load();
     }
@@ -195,10 +195,8 @@ public class EnderStorageManager {
         plugins.put(plugin.identifer(), plugin);
         if (config != null) plugin.loadConfig(config.getTag(plugin.identifer()));
 
-        if (serverManager != null)
-            serverManager.storageList.put(plugin.identifer(), new ArrayList<AbstractEnderStorage>());
-        if (clientManager != null)
-            clientManager.storageList.put(plugin.identifer(), new ArrayList<AbstractEnderStorage>());
+        if (serverManager != null) serverManager.storageList.put(plugin.identifer(), new ArrayList<>());
+        if (clientManager != null) clientManager.storageList.put(plugin.identifer(), new ArrayList<>());
     }
 
     public void requestSave(AbstractEnderStorage storage) {

--- a/src/main/java/codechicken/enderstorage/common/BlockEnderStorage.java
+++ b/src/main/java/codechicken/enderstorage/common/BlockEnderStorage.java
@@ -105,7 +105,7 @@ public class BlockEnderStorage extends BlockContainer {
 
     @Override
     public ArrayList<ItemStack> getDrops(World world, int i, int j, int k, int meta, int fortune) {
-        ArrayList<ItemStack> ret = new ArrayList<ItemStack>();
+        ArrayList<ItemStack> ret = new ArrayList<>();
 
         TileFrequencyOwner tile = (TileFrequencyOwner) world.getTileEntity(i, j, k);
         if (tile != null) {
@@ -182,7 +182,7 @@ public class BlockEnderStorage extends BlockContainer {
         TileFrequencyOwner tile = (TileFrequencyOwner) world.getTileEntity(x, y, z);
         if (tile == null) return null;
 
-        List<IndexedCuboid6> cuboids = new LinkedList<IndexedCuboid6>();
+        List<IndexedCuboid6> cuboids = new LinkedList<>();
         tile.addTraceableCuboids(cuboids);
         return rayTracer.rayTraceCuboids(new Vector3(start), new Vector3(end), cuboids, new BlockCoord(x, y, z), this);
     }

--- a/src/main/java/codechicken/enderstorage/common/BlockEnderStorage.java
+++ b/src/main/java/codechicken/enderstorage/common/BlockEnderStorage.java
@@ -1,7 +1,6 @@
 package codechicken.enderstorage.common;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 
 import net.minecraft.block.BlockContainer;
@@ -182,7 +181,7 @@ public class BlockEnderStorage extends BlockContainer {
         TileFrequencyOwner tile = (TileFrequencyOwner) world.getTileEntity(x, y, z);
         if (tile == null) return null;
 
-        List<IndexedCuboid6> cuboids = new LinkedList<>();
+        List<IndexedCuboid6> cuboids = new ArrayList<>();
         tile.addTraceableCuboids(cuboids);
         return rayTracer.rayTraceCuboids(new Vector3(start), new Vector3(end), cuboids, new BlockCoord(x, y, z), this);
     }

--- a/src/main/java/codechicken/enderstorage/common/ItemEnderStorageRenderer.java
+++ b/src/main/java/codechicken/enderstorage/common/ItemEnderStorageRenderer.java
@@ -45,8 +45,8 @@ public class ItemEnderStorageRenderer implements IItemRenderer {
                 EnderChestRenderer.renderChest(state, rotation, freq, !owner.equals("global"), x, y, z, 0, 0);
                 break;
             case 1:
-                state.reset();
-                state.pullLightmap();
+                state.resetInstance();
+                state.pullLightmapInstance();
                 state.useNormals = true;
                 EnderTankRenderer.renderTank(state, rotation, 0, freq, !owner.equals("global"), x, y, z, 0, false);
                 EnderTankRenderer.renderLiquid(TankSynchroniser.getClientLiquid(freq, owner), x, y, z);

--- a/src/main/java/codechicken/enderstorage/common/ItemEnderStorageRenderer.java
+++ b/src/main/java/codechicken/enderstorage/common/ItemEnderStorageRenderer.java
@@ -48,7 +48,7 @@ public class ItemEnderStorageRenderer implements IItemRenderer {
                 CCRenderState.reset();
                 CCRenderState.pullLightmap();
                 state.useNormals = true;
-                EnderTankRenderer.renderTank(rotation, 0, freq, !owner.equals("global"), x, y, z, 0);
+                EnderTankRenderer.renderTank(rotation, 0, freq, !owner.equals("global"), x, y, z, 0, false);
                 EnderTankRenderer.renderLiquid(TankSynchroniser.getClientLiquid(freq, owner), x, y, z);
                 break;
         }

--- a/src/main/java/codechicken/enderstorage/common/ItemEnderStorageRenderer.java
+++ b/src/main/java/codechicken/enderstorage/common/ItemEnderStorageRenderer.java
@@ -42,13 +42,13 @@ public class ItemEnderStorageRenderer implements IItemRenderer {
         final CCRenderState state = CCRenderState.instance();
         switch (item.getItemDamage() >> 12) {
             case 0:
-                EnderChestRenderer.renderChest(state, rotation, freq, !owner.equals("global"), x, y, z, 0, 0);
+                EnderChestRenderer.renderChest(rotation, freq, !owner.equals("global"), x, y, z, 0, 0);
                 break;
             case 1:
                 CCRenderState.reset();
                 CCRenderState.pullLightmap();
                 state.useNormals = true;
-                EnderTankRenderer.renderTank(state, rotation, 0, freq, !owner.equals("global"), x, y, z, 0);
+                EnderTankRenderer.renderTank(rotation, 0, freq, !owner.equals("global"), x, y, z, 0);
                 EnderTankRenderer.renderLiquid(TankSynchroniser.getClientLiquid(freq, owner), x, y, z);
                 break;
         }

--- a/src/main/java/codechicken/enderstorage/common/ItemEnderStorageRenderer.java
+++ b/src/main/java/codechicken/enderstorage/common/ItemEnderStorageRenderer.java
@@ -45,8 +45,8 @@ public class ItemEnderStorageRenderer implements IItemRenderer {
                 EnderChestRenderer.renderChest(state, rotation, freq, !owner.equals("global"), x, y, z, 0, 0);
                 break;
             case 1:
-                state.reset();
-                state.pullLightmap();
+                CCRenderState.reset();
+                CCRenderState.pullLightmap();
                 state.useNormals = true;
                 EnderTankRenderer.renderTank(state, rotation, 0, freq, !owner.equals("global"), x, y, z, 0);
                 EnderTankRenderer.renderLiquid(TankSynchroniser.getClientLiquid(freq, owner), x, y, z);

--- a/src/main/java/codechicken/enderstorage/common/ItemEnderStorageRenderer.java
+++ b/src/main/java/codechicken/enderstorage/common/ItemEnderStorageRenderer.java
@@ -42,13 +42,13 @@ public class ItemEnderStorageRenderer implements IItemRenderer {
         final CCRenderState state = CCRenderState.instance();
         switch (item.getItemDamage() >> 12) {
             case 0:
-                EnderChestRenderer.renderChest(rotation, freq, !owner.equals("global"), x, y, z, 0, 0);
+                EnderChestRenderer.renderChest(state, rotation, freq, !owner.equals("global"), x, y, z, 0, 0);
                 break;
             case 1:
-                CCRenderState.reset();
-                CCRenderState.pullLightmap();
+                state.reset();
+                state.pullLightmap();
                 state.useNormals = true;
-                EnderTankRenderer.renderTank(rotation, 0, freq, !owner.equals("global"), x, y, z, 0, false);
+                EnderTankRenderer.renderTank(state, rotation, 0, freq, !owner.equals("global"), x, y, z, 0, false);
                 EnderTankRenderer.renderLiquid(TankSynchroniser.getClientLiquid(freq, owner), x, y, z);
                 break;
         }

--- a/src/main/java/codechicken/enderstorage/common/RenderCustomEndPortal.java
+++ b/src/main/java/codechicken/enderstorage/common/RenderCustomEndPortal.java
@@ -7,6 +7,8 @@ import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
+import net.minecraft.tileentity.TileEntityEndPortal;
 import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.ARBVertexBlend;
@@ -16,12 +18,13 @@ public class RenderCustomEndPortal {
 
     private static final ResourceLocation end_skyTex = new ResourceLocation("textures/environment/end_sky.png");
     private static final ResourceLocation end_portalTex = new ResourceLocation("textures/entity/end_portal.png");
+    private static final Random random = new Random(31100L);
 
-    private double surfaceY;
-    private double surfaceX1;
-    private double surfaceX2;
-    private double surfaceZ1;
-    private double surfaceZ2;
+    private final double surfaceY;
+    private final double surfaceX1;
+    private final double surfaceX2;
+    private final double surfaceZ1;
+    private final double surfaceZ2;
 
     FloatBuffer field_40448_a;
 
@@ -34,11 +37,19 @@ public class RenderCustomEndPortal {
         field_40448_a = GLAllocation.createDirectFloatBuffer(16);
     }
 
-    public void render(double posX, double posY, double posZ, float frame, double playerX, double playerY,
-            double playerZ, TextureManager r) {
+    /**
+     * See
+     * {@link net.minecraft.client.renderer.tileentity.RenderEndPortal#renderTileEntityAt(TileEntityEndPortal, double, double, double, float)}
+     */
+    public void renderAt(double posX, double posY, double posZ) {
+        final TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
+        final TextureManager r = info.field_147553_e;
         if (r == null) return;
+        final double viewX = info.field_147560_j;
+        final double viewY = info.field_147561_k;
+        final double viewZ = info.field_147558_l;
         GL11.glDisable(GL11.GL_LIGHTING);
-        Random random = new Random(31100L);
+        random.setSeed(31100L);
         for (int i = 0; i < 16; i++) {
             GL11.glPushMatrix();
             float f5 = 16 - i;
@@ -63,7 +74,7 @@ public class RenderCustomEndPortal {
             float f10 = f8 + f5 + ActiveRenderInfo.objectY;
             float f11 = f9 / f10;
             f11 = (float) (posY + surfaceY) + f11;
-            GL11.glTranslated(playerX, f11, playerZ);
+            GL11.glTranslated(viewX, f11, viewZ);
             GL11.glTexGeni(GL11.GL_S, GL11.GL_TEXTURE_GEN_MODE, GL11.GL_OBJECT_LINEAR);
             GL11.glTexGeni(GL11.GL_T, GL11.GL_TEXTURE_GEN_MODE, GL11.GL_OBJECT_LINEAR);
             GL11.glTexGeni(GL11.GL_R, GL11.GL_TEXTURE_GEN_MODE, GL11.GL_OBJECT_LINEAR);
@@ -85,12 +96,9 @@ public class RenderCustomEndPortal {
             GL11.glTranslatef(0.5F, 0.5F, 0.0F);
             GL11.glRotatef((i * i * 4321 + i * 9) * 2.0F, 0.0F, 0.0F, 1.0F);
             GL11.glTranslatef(-0.5F, -0.5F, 0.0F);
-            GL11.glTranslated(-playerX, -playerZ, -playerY);
+            GL11.glTranslated(-viewX, -viewZ, -viewY);
             f9 = f8 + ActiveRenderInfo.objectY;
-            GL11.glTranslated(
-                    (ActiveRenderInfo.objectX * f5) / f9,
-                    (ActiveRenderInfo.objectZ * f5) / f9,
-                    -playerY + 20);
+            GL11.glTranslated((ActiveRenderInfo.objectX * f5) / f9, (ActiveRenderInfo.objectZ * f5) / f9, -viewY + 20);
             Tessellator tessellator = Tessellator.instance;
             tessellator.startDrawingQuads();
             f11 = random.nextFloat() * 0.5F + 0.1F;

--- a/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
@@ -72,9 +72,9 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
 
             GL11.glDisable(GL11.GL_LIGHTING);
             CCRenderState.changeTexture(HEDRON_TEXTURE);
-            state.startDrawing(4);
+            state.startDrawingInstance(4);
             CCModelLibrary.icosahedron4.render(pearlMat);
-            state.draw();
+            state.drawInstance();
             GL11.glEnable(GL11.GL_LIGHTING);
         }
     }
@@ -127,8 +127,8 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
 
     public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float partialTicks) {
         final CCRenderState state = CCRenderState.instance();
-        state.reset();
-        state.setBrightness(tile.getWorldObj(), tile.xCoord, tile.yCoord, tile.zCoord);
+        state.resetInstance();
+        state.setBrightnessInstance(tile.getWorldObj(), tile.xCoord, tile.yCoord, tile.zCoord);
         state.useNormals = true;
 
         TileEnderChest chest = (TileEnderChest) tile;

--- a/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
@@ -26,8 +26,8 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
 
     public EnderChestRenderer() {}
 
-    public static void renderChest(CCRenderState state, int rotation, int freq, boolean owned, double x, double y,
-            double z, int offset, float lidAngle) {
+    public static void renderChest(int rotation, int freq, boolean owned, double x, double y, double z, int offset,
+            float lidAngle) {
         if (!EnderStorage.disableFXChest) {
             TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
             renderEndPortal.render(
@@ -137,7 +137,6 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
 
         TileEnderChest chest = (TileEnderChest) tile;
         renderChest(
-                state,
                 chest.rotation,
                 chest.freq,
                 !chest.owner.equals("global"),
@@ -145,7 +144,7 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
                 y,
                 z,
                 EnderStorageClientProxy.getTimeOffset(chest.xCoord, chest.yCoord, chest.zCoord),
-                (float) chest.getRadianLidAngle(partialTicks));
+                chest.getRadianLidAngle(partialTicks));
     }
 
     public static final double phi = 1.618034;

--- a/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
@@ -42,7 +42,7 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
         }
         GL11.glColor4f(1, 1, 1, 1);
 
-        state.changeTexture("enderstorage:textures/enderchest.png");
+        CCRenderState.changeTexture("enderstorage:textures/enderchest.png");
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPushMatrix();
         GL11.glColor4f(1, 1, 1, 1);
@@ -68,10 +68,10 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
                 0.04);
 
         GL11.glDisable(GL11.GL_LIGHTING);
-        state.changeTexture("enderstorage:textures/hedronmap.png");
-        state.startDrawing(4);
+        CCRenderState.changeTexture("enderstorage:textures/hedronmap.png");
+        CCRenderState.startDrawing(4);
         CCModelLibrary.icosahedron4.render(pearlMat);
-        state.draw();
+        CCRenderState.draw();
         GL11.glEnable(GL11.GL_LIGHTING);
     }
 
@@ -129,10 +129,10 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
         Tessellator.instance.addVertexWithUV(vec.x, vec.y, vec.z, u, v);
     }
 
-    public void renderTileEntityAt(TileEntity tile, double d, double d1, double d2, float f) {
+    public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float partialTicks) {
         final CCRenderState state = CCRenderState.instance();
-        state.reset();
-        state.setBrightness(tile.getWorldObj(), tile.xCoord, tile.yCoord, tile.zCoord);
+        CCRenderState.reset();
+        CCRenderState.setBrightness(tile.getWorldObj(), tile.xCoord, tile.yCoord, tile.zCoord);
         state.useNormals = true;
 
         TileEnderChest chest = (TileEnderChest) tile;
@@ -141,11 +141,11 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
                 chest.rotation,
                 chest.freq,
                 !chest.owner.equals("global"),
-                d,
-                d1,
-                d2,
+                x,
+                y,
+                z,
                 EnderStorageClientProxy.getTimeOffset(chest.xCoord, chest.yCoord, chest.zCoord),
-                (float) chest.getRadianLidAngle(f));
+                (float) chest.getRadianLidAngle(partialTicks));
     }
 
     public static final double phi = 1.618034;

--- a/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
@@ -25,15 +25,15 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
 
     public EnderChestRenderer() {}
 
-    public static void renderChest(int rotation, int freq, boolean owned, double x, double y, double z, int offset,
-            float lidAngle) {
+    public static void renderChest(CCRenderState state, int rotation, int freq, boolean owned, double x, double y,
+            double z, int offset, float lidAngle) {
         final boolean isChestOpen = lidAngle < 0f;
         if (isChestOpen && !EnderStorage.disableFXChest) {
             renderEndPortal.renderAt(x, y, z);
         }
         GL11.glColor4f(1, 1, 1, 1);
 
-        CCRenderState.changeTexture("enderstorage:textures/enderchest.png");
+        state.changeTexture("enderstorage:textures/enderchest.png");
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPushMatrix();
         GL11.glColor4f(1, 1, 1, 1);
@@ -48,7 +48,7 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
 
         GL11.glPushMatrix();
         GL11.glTranslated(x, y, z);
-        CCRenderState.changeTexture("enderstorage:textures/buttons.png");
+        state.changeTexture("enderstorage:textures/buttons.png");
         drawButton(0, EnderStorageManager.getColourFromFreq(freq, 0), rotation, lidAngle);
         drawButton(1, EnderStorageManager.getColourFromFreq(freq, 1), rotation, lidAngle);
         drawButton(2, EnderStorageManager.getColourFromFreq(freq, 2), rotation, lidAngle);
@@ -66,10 +66,10 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
                     0.04);
 
             GL11.glDisable(GL11.GL_LIGHTING);
-            CCRenderState.changeTexture("enderstorage:textures/hedronmap.png");
-            CCRenderState.startDrawing(4);
+            state.changeTexture("enderstorage:textures/hedronmap.png");
+            state.startDrawing(4);
             CCModelLibrary.icosahedron4.render(pearlMat);
-            CCRenderState.draw();
+            state.draw();
             GL11.glEnable(GL11.GL_LIGHTING);
         }
     }
@@ -122,12 +122,13 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
 
     public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float partialTicks) {
         final CCRenderState state = CCRenderState.instance();
-        CCRenderState.reset();
-        CCRenderState.setBrightness(tile.getWorldObj(), tile.xCoord, tile.yCoord, tile.zCoord);
+        state.reset();
+        state.setBrightness(tile.getWorldObj(), tile.xCoord, tile.yCoord, tile.zCoord);
         state.useNormals = true;
 
         TileEnderChest chest = (TileEnderChest) tile;
         renderChest(
+                state,
                 chest.rotation,
                 chest.freq,
                 !chest.owner.equals("global"),

--- a/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
@@ -28,7 +28,8 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
 
     public static void renderChest(int rotation, int freq, boolean owned, double x, double y, double z, int offset,
             float lidAngle) {
-        if (!EnderStorage.disableFXChest) {
+        final boolean isChestOpen = lidAngle < 0f;
+        if (isChestOpen && !EnderStorage.disableFXChest) {
             TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
             renderEndPortal.render(
                     x,
@@ -57,30 +58,30 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
 
         GL11.glPushMatrix();
         GL11.glTranslated(x, y, z);
-        renderButtons(freq, rotation, lidAngle);
+        CCRenderState.changeTexture("enderstorage:textures/buttons.png");
+        drawButton(0, EnderStorageManager.getColourFromFreq(freq, 0), rotation, lidAngle);
+        drawButton(1, EnderStorageManager.getColourFromFreq(freq, 1), rotation, lidAngle);
+        drawButton(2, EnderStorageManager.getColourFromFreq(freq, 2), rotation, lidAngle);
         GL11.glPopMatrix();
         GL11.glDisable(GL12.GL_RESCALE_NORMAL);
 
-        double time = ClientUtils.getRenderTime() + offset;
-        Matrix4 pearlMat = CCModelLibrary.getRenderMatrix(
-                new Vector3(x + 0.5, y + 0.2 + lidAngle * -0.5 + EnderStorageClientProxy.getPearlBob(time), z + 0.5),
-                new Rotation(time / 3, Y),
-                0.04);
+        if (isChestOpen) {
+            double time = ClientUtils.getRenderTime() + offset;
+            Matrix4 pearlMat = CCModelLibrary.getRenderMatrix(
+                    new Vector3(
+                            x + 0.5,
+                            y + 0.2 + lidAngle * -0.5 + EnderStorageClientProxy.getPearlBob(time),
+                            z + 0.5),
+                    new Rotation(time / 3, Y),
+                    0.04);
 
-        GL11.glDisable(GL11.GL_LIGHTING);
-        CCRenderState.changeTexture("enderstorage:textures/hedronmap.png");
-        CCRenderState.startDrawing(4);
-        CCModelLibrary.icosahedron4.render(pearlMat);
-        CCRenderState.draw();
-        GL11.glEnable(GL11.GL_LIGHTING);
-    }
-
-    private static void renderButtons(int freq, int rot, double lidAngle) {
-        CCRenderState.changeTexture("enderstorage:textures/buttons.png");
-
-        drawButton(0, EnderStorageManager.getColourFromFreq(freq, 0), rot, lidAngle);
-        drawButton(1, EnderStorageManager.getColourFromFreq(freq, 1), rot, lidAngle);
-        drawButton(2, EnderStorageManager.getColourFromFreq(freq, 2), rot, lidAngle);
+            GL11.glDisable(GL11.GL_LIGHTING);
+            CCRenderState.changeTexture("enderstorage:textures/hedronmap.png");
+            CCRenderState.startDrawing(4);
+            CCModelLibrary.icosahedron4.render(pearlMat);
+            CCRenderState.draw();
+            GL11.glEnable(GL11.GL_LIGHTING);
+        }
     }
 
     private static void drawButton(int button, int colour, int rot, double lidAngle) {

--- a/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
@@ -1,7 +1,6 @@
 package codechicken.enderstorage.storage.item;
 
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 
@@ -30,16 +29,7 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
             float lidAngle) {
         final boolean isChestOpen = lidAngle < 0f;
         if (isChestOpen && !EnderStorage.disableFXChest) {
-            TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
-            renderEndPortal.render(
-                    x,
-                    y,
-                    z,
-                    0,
-                    info.field_147560_j,
-                    info.field_147560_j,
-                    info.field_147561_k,
-                    info.field_147553_e);
+            renderEndPortal.renderAt(x, y, z);
         }
         GL11.glColor4f(1, 1, 1, 1);
 

--- a/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
@@ -3,6 +3,7 @@ package codechicken.enderstorage.storage.item;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
@@ -20,6 +21,10 @@ import codechicken.lib.vec.Vector3;
 
 public class EnderChestRenderer extends TileEntitySpecialRenderer {
 
+    private static final ResourceLocation ENDERCHEST_TEXTURE = new ResourceLocation(
+            "enderstorage:textures/enderchest.png");
+    private static final ResourceLocation BUTTONS_TEXTURE = new ResourceLocation("enderstorage:textures/buttons.png");
+    private static final ResourceLocation HEDRON_TEXTURE = new ResourceLocation("enderstorage:textures/hedronmap.png");
     private static final ModelEnderChest model = new ModelEnderChest();
     private static final Vector3 Y = new Vector3(0, 1, 0);
 
@@ -33,7 +38,7 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
         }
         GL11.glColor4f(1, 1, 1, 1);
 
-        state.changeTexture("enderstorage:textures/enderchest.png");
+        CCRenderState.changeTexture(ENDERCHEST_TEXTURE);
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glPushMatrix();
         GL11.glColor4f(1, 1, 1, 1);
@@ -48,7 +53,7 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
 
         GL11.glPushMatrix();
         GL11.glTranslated(x, y, z);
-        state.changeTexture("enderstorage:textures/buttons.png");
+        CCRenderState.changeTexture(BUTTONS_TEXTURE);
         drawButton(0, EnderStorageManager.getColourFromFreq(freq, 0), rotation, lidAngle);
         drawButton(1, EnderStorageManager.getColourFromFreq(freq, 1), rotation, lidAngle);
         drawButton(2, EnderStorageManager.getColourFromFreq(freq, 2), rotation, lidAngle);
@@ -66,7 +71,7 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
                     0.04);
 
             GL11.glDisable(GL11.GL_LIGHTING);
-            state.changeTexture("enderstorage:textures/hedronmap.png");
+            CCRenderState.changeTexture(HEDRON_TEXTURE);
             state.startDrawing(4);
             CCModelLibrary.icosahedron4.render(pearlMat);
             state.draw();

--- a/src/main/java/codechicken/enderstorage/storage/item/GuiEnderItemStorage.java
+++ b/src/main/java/codechicken/enderstorage/storage/item/GuiEnderItemStorage.java
@@ -3,6 +3,7 @@ package codechicken.enderstorage.storage.item;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
@@ -11,9 +12,14 @@ import codechicken.lib.render.CCRenderState;
 
 public class GuiEnderItemStorage extends GuiContainer {
 
-    private String name;
-    private IInventory playerInv;
-    private EnderItemStorage chestInv;
+    private static final ResourceLocation DISPENSER_TEXTURE = new ResourceLocation(
+            "textures/gui/container/dispenser.png");
+    private static final ResourceLocation GENERIC_54_TEXTURE = new ResourceLocation(
+            "textures/gui/container/generic_54.png");
+
+    private final String name;
+    private final IInventory playerInv;
+    private final EnderItemStorage chestInv;
 
     public GuiEnderItemStorage(InventoryPlayer invplayer, EnderItemStorage chestInv, String name) {
         super(new ContainerEnderItemStorage(invplayer, chestInv, true));
@@ -37,9 +43,7 @@ public class GuiEnderItemStorage extends GuiContainer {
 
     protected void drawGuiContainerBackgroundLayer(float f, int i, int j) {
         GL11.glColor4f(1, 1, 1, 1);
-        CCRenderState.changeTexture(
-                chestInv.getSize() == 0 ? "textures/gui/container/dispenser.png"
-                        : "textures/gui/container/generic_54.png");
+        CCRenderState.changeTexture(chestInv.getSize() == 0 ? DISPENSER_TEXTURE : GENERIC_54_TEXTURE);
         int x = (width - xSize) / 2;
         int y = (height - ySize) / 2;
 

--- a/src/main/java/codechicken/enderstorage/storage/item/TileEnderChest.java
+++ b/src/main/java/codechicken/enderstorage/storage/item/TileEnderChest.java
@@ -21,8 +21,8 @@ import codechicken.lib.vec.Vector3;
 
 public class TileEnderChest extends TileFrequencyOwner implements IInventory {
 
-    public double a_lidAngle;
-    public double b_lidAngle;
+    public float lidAngle;
+    public float prevLidAngle;
     public int c_numOpen;
     public int rotation;
 
@@ -44,12 +44,14 @@ public class TileEnderChest extends TileFrequencyOwner implements IInventory {
 
     public TileEnderChest() {}
 
+    @Override
     public void updateEntity() {
         super.updateEntity();
 
-        // update compatiblity
-        if (worldObj.getBlockMetadata(xCoord, yCoord, zCoord) != 0) {
-            rotation = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
+        // update compatibility
+        final int blockMeta = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
+        if (blockMeta != 0) {
+            rotation = blockMeta;
             worldObj.setBlockMetadataWithNotify(xCoord, yCoord, zCoord, 0, 3);
         }
 
@@ -58,23 +60,26 @@ public class TileEnderChest extends TileFrequencyOwner implements IInventory {
             worldObj.addBlockEvent(xCoord, yCoord, zCoord, EnderStorage.blockEnderChest, 1, c_numOpen);
         }
 
-        b_lidAngle = a_lidAngle;
-        a_lidAngle = MathHelper.approachLinear(a_lidAngle, c_numOpen > 0 ? 1 : 0, 0.1);
+        prevLidAngle = lidAngle;
+        lidAngle = MathHelper.approachLinear(lidAngle, c_numOpen > 0 ? 1f : 0f, 0.1f);
 
-        if (b_lidAngle >= 0.5 && a_lidAngle < 0.5) worldObj.playSoundEffect(
-                xCoord + 0.5,
-                yCoord + 0.5,
-                zCoord + 0.5,
-                "random.chestclosed",
-                0.5F,
-                worldObj.rand.nextFloat() * 0.1F + 0.9F);
-        else if (b_lidAngle == 0 && a_lidAngle > 0) worldObj.playSoundEffect(
-                xCoord + 0.5,
-                yCoord + 0.5,
-                zCoord + 0.5,
-                "random.chestopen",
-                0.5F,
-                worldObj.rand.nextFloat() * 0.1F + 0.9F);
+        if (prevLidAngle >= 0.5f && lidAngle < 0.5f) {
+            worldObj.playSoundEffect(
+                    xCoord + 0.5,
+                    yCoord + 0.5,
+                    zCoord + 0.5,
+                    "random.chestclosed",
+                    0.5F,
+                    worldObj.rand.nextFloat() * 0.1F + 0.9F);
+        } else if (prevLidAngle == 0f && lidAngle > 0f) {
+            worldObj.playSoundEffect(
+                    xCoord + 0.5,
+                    yCoord + 0.5,
+                    zCoord + 0.5,
+                    "random.chestopen",
+                    0.5F,
+                    worldObj.rand.nextFloat() * 0.1F + 0.9F);
+        }
     }
 
     @Override
@@ -86,11 +91,11 @@ public class TileEnderChest extends TileFrequencyOwner implements IInventory {
         return false;
     }
 
-    public double getRadianLidAngle(float frame) {
-        double a = MathHelper.interpolate(b_lidAngle, a_lidAngle, frame);
+    public float getRadianLidAngle(float partialTicks) {
+        float a = MathHelper.interpolate(prevLidAngle, lidAngle, partialTicks);
         a = 1.0F - a;
         a = 1.0F - a * a * a;
-        return a * 3.141593 * -0.5;
+        return a * 3.141593f * -0.5f;
     }
 
     public void reloadStorage() {

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -93,7 +93,6 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         state.useNormals = true;
 
         renderTank(
-                state,
                 tank.rotation,
                 (float) MathHelper.interpolate(tank.pressure_state.b_rotate, tank.pressure_state.a_rotate, f)
                         * 0.01745F,
@@ -106,8 +105,8 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         renderLiquid(tank.liquid_state.c_liquid, x, y, z);
     }
 
-    public static void renderTank(CCRenderState state, int rotation, float valve, int freq, boolean owned, double x,
-            double y, double z, int offset) {
+    public static void renderTank(int rotation, float valve, int freq, boolean owned, double x, double y, double z,
+            int offset) {
         if (!EnderStorage.disableFXTank) {
             TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
             renderEndPortal.render(

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -88,11 +88,12 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         TileEnderTank tank = (TileEnderTank) tile;
 
         final CCRenderState state = CCRenderState.instance();
-        CCRenderState.reset();
-        CCRenderState.pullLightmap();
+        state.reset();
+        state.pullLightmap();
         state.useNormals = true;
 
         renderTank(
+                state,
                 tank.rotation,
                 (float) MathHelper.interpolate(tank.pressure_state.b_rotate, tank.pressure_state.a_rotate, f)
                         * 0.01745F,
@@ -117,8 +118,8 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
     /**
      * @param renderFx set to true to render the portal texture and the floating hedron
      */
-    public static void renderTank(int rotation, float valve, int freq, boolean owned, double x, double y, double z,
-            int offset, boolean renderFx) {
+    public static void renderTank(CCRenderState state, int rotation, float valve, int freq, boolean owned, double x,
+            double y, double z, int offset, boolean renderFx) {
         if (renderFx && !EnderStorage.disableFXTank) {
             renderEndPortal.renderAt(x, y, z);
         }
@@ -129,25 +130,25 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         GL11.glTranslated(x + 0.5, y, z + 0.5);
         GL11.glRotatef(-90 * (rotation + 2), 0, 1, 0);
 
-        CCRenderState.changeTexture("enderstorage:textures/endertank.png");
-        CCRenderState.startDrawing(4);
+        state.changeTexture("enderstorage:textures/endertank.png");
+        state.startDrawing(4);
         tankModel.render();
-        CCRenderState.draw();
+        state.draw();
 
-        CCRenderState.changeTexture("enderstorage:textures/buttons.png");
-        CCRenderState.startDrawing(7);
+        state.changeTexture("enderstorage:textures/buttons.png");
+        state.startDrawing(7);
         for (int i = 0; i < 3; i++) {
             int colour = EnderStorageManager.getColourFromFreq(freq, i);
             buttons[i].render(UVTranslationButtons[colour]);
         }
-        CCRenderState.draw();
+        state.draw();
 
         new Rotation(valve, Z).at(point).glApply();
 
-        CCRenderState.changeTexture("enderstorage:textures/endertank.png");
-        CCRenderState.startDrawing(4);
+        state.changeTexture("enderstorage:textures/endertank.png");
+        state.startDrawing(4);
         valveModel.render(owned ? UVTvalveOwned : UVTvalveNotOwned);
-        CCRenderState.draw();
+        state.draw();
         GL11.glPopMatrix();
         GL11.glDisable(GL12.GL_RESCALE_NORMAL);
 
@@ -158,10 +159,10 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
                     new Rotation(time / 3, Y),
                     0.04);
             GL11.glDisable(GL11.GL_LIGHTING);
-            CCRenderState.changeTexture("enderstorage:textures/hedronmap.png");
-            CCRenderState.startDrawing(4);
+            state.changeTexture("enderstorage:textures/hedronmap.png");
+            state.startDrawing(4);
             CCModelLibrary.icosahedron4.render(pearlMat);
-            CCRenderState.draw();
+            state.draw();
             GL11.glEnable(GL11.GL_LIGHTING);
         }
     }

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -93,8 +93,8 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         TileEnderTank tank = (TileEnderTank) tile;
 
         final CCRenderState state = CCRenderState.instance();
-        state.reset();
-        state.pullLightmap();
+        state.resetInstance();
+        state.pullLightmapInstance();
         state.useNormals = true;
 
         renderTank(
@@ -136,24 +136,24 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         GL11.glRotatef(-90 * (rotation + 2), 0, 1, 0);
 
         CCRenderState.changeTexture(ENDERTANK_TEXTURE);
-        state.startDrawing(4);
+        state.startDrawingInstance(4);
         tankModel.render();
-        state.draw();
+        state.drawInstance();
 
         CCRenderState.changeTexture(BUTTONS_TEXTURE);
-        state.startDrawing(7);
+        state.startDrawingInstance(7);
         for (int i = 0; i < 3; i++) {
             int colour = EnderStorageManager.getColourFromFreq(freq, i);
             buttons[i].render(UVTranslationButtons[colour]);
         }
-        state.draw();
+        state.drawInstance();
 
         new Rotation(valve, Z).at(point).glApply();
 
         CCRenderState.changeTexture(ENDERTANK_TEXTURE);
-        state.startDrawing(4);
+        state.startDrawingInstance(4);
         valveModel.render(owned ? UVTvalveOwned : UVTvalveNotOwned);
-        state.draw();
+        state.drawInstance();
         GL11.glPopMatrix();
         GL11.glDisable(GL12.GL_RESCALE_NORMAL);
 
@@ -165,9 +165,9 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
                     0.04);
             GL11.glDisable(GL11.GL_LIGHTING);
             CCRenderState.changeTexture(HEDRON_TEXTURE);
-            state.startDrawing(4);
+            state.startDrawingInstance(4);
             CCModelLibrary.icosahedron4.render(pearlMat);
-            state.draw();
+            state.drawInstance();
             GL11.glEnable(GL11.GL_LIGHTING);
         }
     }

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -3,7 +3,6 @@ package codechicken.enderstorage.storage.liquid;
 import java.util.ArrayList;
 import java.util.Map;
 
-import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
@@ -112,16 +111,7 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
     public static void renderTank(int rotation, float valve, int freq, boolean owned, double x, double y, double z,
             int offset, boolean renderFx) {
         if (renderFx && !EnderStorage.disableFXTank) {
-            TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
-            renderEndPortal.render(
-                    x,
-                    y,
-                    z,
-                    0,
-                    info.field_147560_j,
-                    info.field_147560_j,
-                    info.field_147561_k,
-                    info.field_147553_e);
+            renderEndPortal.renderAt(x, y, z);
         }
         GL11.glColor4f(1, 1, 1, 1);
 

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -56,7 +56,7 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
     static {
         Map<String, CCModel> models = CCModel
                 .parseObjModels(new ResourceLocation("enderstorage", "models/endertank.obj"), new SwapYZ());
-        ArrayList<CCModel> tankParts = new ArrayList<CCModel>();
+        ArrayList<CCModel> tankParts = new ArrayList<>();
         tankParts.add(models.get("Blazerod1"));
         tankParts.add(models.get("Blazerod2"));
         tankParts.add(models.get("Blazerod3"));
@@ -73,8 +73,10 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         valveModel = models.get("Valve").apply(fix).computeNormals();
 
         buttons = new CCModel[3];
-        for (int i = 0; i < 3; i++) buttons[i] = RenderEnderStorage.button.copy()
-                .apply(TileEnderTank.buttonT[i].with(new Translation(-0.5, 0, -0.5)));
+        for (int i = 0; i < 3; i++) {
+            buttons[i] = RenderEnderStorage.button.copy()
+                    .apply(TileEnderTank.buttonT[i].with(new Translation(-0.5, 0, -0.5)));
+        }
 
         for (int colour = 0; colour < 16; colour++) {
             UVTranslationButtons[colour] = new UVTranslation(0.25 * (colour % 4), 0.25 * (colour / 4));
@@ -86,8 +88,8 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         TileEnderTank tank = (TileEnderTank) tile;
 
         final CCRenderState state = CCRenderState.instance();
-        state.reset();
-        state.pullLightmap();
+        CCRenderState.reset();
+        CCRenderState.pullLightmap();
         state.useNormals = true;
 
         renderTank(
@@ -125,25 +127,25 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         GL11.glTranslated(x + 0.5, y, z + 0.5);
         GL11.glRotatef(-90 * (rotation + 2), 0, 1, 0);
 
-        state.changeTexture("enderstorage:textures/endertank.png");
-        state.startDrawing(4);
+        CCRenderState.changeTexture("enderstorage:textures/endertank.png");
+        CCRenderState.startDrawing(4);
         tankModel.render();
-        state.draw();
+        CCRenderState.draw();
 
-        state.changeTexture("enderstorage:textures/buttons.png");
-        state.startDrawing(7);
+        CCRenderState.changeTexture("enderstorage:textures/buttons.png");
+        CCRenderState.startDrawing(7);
         for (int i = 0; i < 3; i++) {
             int colour = EnderStorageManager.getColourFromFreq(freq, i);
             buttons[i].render(UVTranslationButtons[colour]);
         }
-        state.draw();
+        CCRenderState.draw();
 
         new Rotation(valve, Z).at(point).glApply();
 
-        state.changeTexture("enderstorage:textures/endertank.png");
-        state.startDrawing(4);
+        CCRenderState.changeTexture("enderstorage:textures/endertank.png");
+        CCRenderState.startDrawing(4);
         valveModel.render(owned ? UVTvalveOwned : UVTvalveNotOwned);
-        state.draw();
+        CCRenderState.draw();
         GL11.glPopMatrix();
         GL11.glDisable(GL12.GL_RESCALE_NORMAL);
 
@@ -154,10 +156,10 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
                 0.04);
 
         GL11.glDisable(GL11.GL_LIGHTING);
-        state.changeTexture("enderstorage:textures/hedronmap.png");
-        state.startDrawing(4);
+        CCRenderState.changeTexture("enderstorage:textures/hedronmap.png");
+        CCRenderState.startDrawing(4);
         CCModelLibrary.icosahedron4.render(pearlMat);
-        state.draw();
+        CCRenderState.draw();
         GL11.glEnable(GL11.GL_LIGHTING);
     }
 

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -101,13 +101,17 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
                 x,
                 y,
                 z,
-                EnderStorageClientProxy.getTimeOffset(tile.xCoord, tile.yCoord, tile.zCoord));
+                EnderStorageClientProxy.getTimeOffset(tile.xCoord, tile.yCoord, tile.zCoord),
+                true);
         renderLiquid(tank.liquid_state.c_liquid, x, y, z);
     }
 
+    /**
+     * @param renderFx set to true to render the portal texture and the floating hedron
+     */
     public static void renderTank(int rotation, float valve, int freq, boolean owned, double x, double y, double z,
-            int offset) {
-        if (!EnderStorage.disableFXTank) {
+            int offset, boolean renderFx) {
+        if (renderFx && !EnderStorage.disableFXTank) {
             TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
             renderEndPortal.render(
                     x,
@@ -148,18 +152,19 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         GL11.glPopMatrix();
         GL11.glDisable(GL12.GL_RESCALE_NORMAL);
 
-        double time = ClientUtils.getRenderTime() + offset;
-        Matrix4 pearlMat = CCModelLibrary.getRenderMatrix(
-                new Vector3(x + 0.5, y + 0.45 + EnderStorageClientProxy.getPearlBob(time) * 2, z + 0.5),
-                new Rotation(time / 3, Y),
-                0.04);
-
-        GL11.glDisable(GL11.GL_LIGHTING);
-        CCRenderState.changeTexture("enderstorage:textures/hedronmap.png");
-        CCRenderState.startDrawing(4);
-        CCModelLibrary.icosahedron4.render(pearlMat);
-        CCRenderState.draw();
-        GL11.glEnable(GL11.GL_LIGHTING);
+        if (renderFx) {
+            double time = ClientUtils.getRenderTime() + offset;
+            Matrix4 pearlMat = CCModelLibrary.getRenderMatrix(
+                    new Vector3(x + 0.5, y + 0.45 + EnderStorageClientProxy.getPearlBob(time) * 2, z + 0.5),
+                    new Rotation(time / 3, Y),
+                    0.04);
+            GL11.glDisable(GL11.GL_LIGHTING);
+            CCRenderState.changeTexture("enderstorage:textures/hedronmap.png");
+            CCRenderState.startDrawing(4);
+            CCModelLibrary.icosahedron4.render(pearlMat);
+            CCRenderState.draw();
+            GL11.glEnable(GL11.GL_LIGHTING);
+        }
     }
 
     public static void renderLiquid(FluidStack liquid, double x, double y, double z) {

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -3,6 +3,7 @@ package codechicken.enderstorage.storage.liquid;
 import java.util.ArrayList;
 import java.util.Map;
 
+import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
@@ -101,8 +102,16 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
                 y,
                 z,
                 EnderStorageClientProxy.getTimeOffset(tile.xCoord, tile.yCoord, tile.zCoord),
-                true);
+                shouldRenderFx(tile)); // only render when within 16 blocks
         renderLiquid(tank.liquid_state.c_liquid, x, y, z);
+    }
+
+    private static boolean shouldRenderFx(TileEntity tile) {
+        final TileEntityRendererDispatcher info = TileEntityRendererDispatcher.instance;
+        final double viewX = info.field_147560_j;
+        final double viewY = info.field_147561_k;
+        final double viewZ = info.field_147558_l;
+        return tile.getDistanceFrom(viewX, viewY, viewZ) < 256d;
     }
 
     /**

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -35,6 +35,11 @@ import codechicken.lib.vec.Vector3;
 
 public class EnderTankRenderer extends TileEntitySpecialRenderer {
 
+    private static final ResourceLocation ENDERTANK_TEXTURE = new ResourceLocation(
+            "enderstorage:textures/endertank.png");
+    private static final ResourceLocation BUTTONS_TEXTURE = new ResourceLocation("enderstorage:textures/buttons.png");
+    private static final ResourceLocation HEDRON_TEXTURE = new ResourceLocation("enderstorage:textures/hedronmap.png");
+
     private static final CCModel tankModel;
     private static final CCModel valveModel;
     private static final CCModel[] buttons;
@@ -130,12 +135,12 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         GL11.glTranslated(x + 0.5, y, z + 0.5);
         GL11.glRotatef(-90 * (rotation + 2), 0, 1, 0);
 
-        state.changeTexture("enderstorage:textures/endertank.png");
+        CCRenderState.changeTexture(ENDERTANK_TEXTURE);
         state.startDrawing(4);
         tankModel.render();
         state.draw();
 
-        state.changeTexture("enderstorage:textures/buttons.png");
+        CCRenderState.changeTexture(BUTTONS_TEXTURE);
         state.startDrawing(7);
         for (int i = 0; i < 3; i++) {
             int colour = EnderStorageManager.getColourFromFreq(freq, i);
@@ -145,7 +150,7 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
 
         new Rotation(valve, Z).at(point).glApply();
 
-        state.changeTexture("enderstorage:textures/endertank.png");
+        CCRenderState.changeTexture(ENDERTANK_TEXTURE);
         state.startDrawing(4);
         valveModel.render(owned ? UVTvalveOwned : UVTvalveNotOwned);
         state.draw();
@@ -159,7 +164,7 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
                     new Rotation(time / 3, Y),
                     0.04);
             GL11.glDisable(GL11.GL_LIGHTING);
-            state.changeTexture("enderstorage:textures/hedronmap.png");
+            CCRenderState.changeTexture(HEDRON_TEXTURE);
             state.startDrawing(4);
             CCModelLibrary.icosahedron4.render(pearlMat);
             state.draw();

--- a/src/main/java/codechicken/enderstorage/storage/liquid/TankSynchroniser.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/TankSynchroniser.java
@@ -118,7 +118,7 @@ public class TankSynchroniser {
     public static class PlayerItemTankCache {
 
         private boolean client;
-        private HashMap<String, PlayerItemTankState> tankStates = new HashMap<String, PlayerItemTankState>();
+        private HashMap<String, PlayerItemTankState> tankStates = new HashMap<>();
         // client
         private HashSet<String> b_visible;
         private HashSet<String> a_visible;
@@ -132,8 +132,8 @@ public class TankSynchroniser {
 
         public PlayerItemTankCache() {
             client = true;
-            a_visible = new HashSet<String>();
-            b_visible = new HashSet<String>();
+            a_visible = new HashSet<>();
+            b_visible = new HashSet<>();
         }
 
         public void track(int freq, String owner, boolean t) {
@@ -266,6 +266,6 @@ public class TankSynchroniser {
     @SubscribeEvent
     public void onWorldLoad(Load event) {
         if (event.world.isRemote) clientState = new PlayerItemTankCache();
-        else if (playerItemTankStates == null) playerItemTankStates = new HashMap<String, PlayerItemTankCache>();
+        else if (playerItemTankStates == null) playerItemTankStates = new HashMap<>();
     }
 }


### PR DESCRIPTION
- stop rendering the portal and hedron texture when the ender chest is closed
- stop rendering the portal and hedron texture for the ender tank when rendering as an inventory item
- only render the portal and hedron texture for the ender tank when within 16 blocks

None of the method signature changed are used outside of this mod, so it will not cause any crash. All the rendering works as intended which provides a big fps boost, or should as say it doesn't tank the fps as much as before.