### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/enderstorage/lang/en_US.lang
+++ b/src/main/resources/assets/enderstorage/lang/en_US.lang
@@ -1,3 +1,4 @@
+tile.enderchest.name=Ender Chest/Tank
 tile.enderchest|0.name=Ender Chest
 tile.enderchest|1.name=Ender Tank
 item.enderpouch.name=Ender Pouch


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.