### PR TITLE
Fix incorrect lighting on AE2 GUI

### DIFF
--- a/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
@@ -6,7 +6,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL12;
 
 import codechicken.core.ClientUtils;
 import codechicken.enderstorage.EnderStorage;

--- a/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/item/EnderChestRenderer.java
@@ -39,7 +39,7 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
         GL11.glColor4f(1, 1, 1, 1);
 
         CCRenderState.changeTexture(ENDERCHEST_TEXTURE);
-        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+        GL11.glEnable(GL11.GL_NORMALIZE);
         GL11.glPushMatrix();
         GL11.glColor4f(1, 1, 1, 1);
         GL11.glTranslated(x, y + 1.0, z + 1.0F);
@@ -58,7 +58,7 @@ public class EnderChestRenderer extends TileEntitySpecialRenderer {
         drawButton(1, EnderStorageManager.getColourFromFreq(freq, 1), rotation, lidAngle);
         drawButton(2, EnderStorageManager.getColourFromFreq(freq, 2), rotation, lidAngle);
         GL11.glPopMatrix();
-        GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+        GL11.glDisable(GL11.GL_NORMALIZE);
 
         if (isChestOpen) {
             double time = ClientUtils.getRenderTime() + offset;

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -10,7 +10,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidStack;
 
 import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL12;
 
 import codechicken.core.ClientUtils;
 import codechicken.core.fluid.FluidUtils;

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -130,7 +130,7 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         }
         GL11.glColor4f(1, 1, 1, 1);
 
-        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+        GL11.glEnable(GL11.GL_NORMALIZE);
         GL11.glPushMatrix();
         GL11.glTranslated(x + 0.5, y, z + 0.5);
         GL11.glRotatef(-90 * (rotation + 2), 0, 1, 0);
@@ -155,7 +155,7 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         valveModel.render(owned ? UVTvalveOwned : UVTvalveNotOwned);
         state.drawInstance();
         GL11.glPopMatrix();
-        GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+        GL11.glDisable(GL11.GL_NORMALIZE);
 
         if (renderFx) {
             double time = ClientUtils.getRenderTime() + offset;


### PR DESCRIPTION
As everyone knows EnderChest & EnderTank will cause all other slot dark on an AE2 GUI, including terminals and me chest.
![image](https://github.com/user-attachments/assets/6385cd23-30b8-424e-86a1-dcf1f6ebfeed)
GL_NORMALIZE has better compatibility then GL_RESCALE_NORMALS and could fix it.