### PR TITLE
Re-encode `sv_SV.lang` into UTF-8

### DIFF
--- a/src/main/resources/assets/enderstorage/lang/sv_SV.lang
+++ b/src/main/resources/assets/enderstorage/lang/sv_SV.lang
@@ -1,4 +1,4 @@
 tile.enderchest|0.name=Enderkista
 tile.enderchest|1.name=Endertank
-item.enderpouch.name=Enderpåse
-enderstorage.serverop=Operatör
+item.enderpouch.name=EnderpÃ¥se
+enderstorage.serverop=OperatÃ¶r


### PR DESCRIPTION
See my previous PRs. Changed encoding from Windows-1252 to UTF-8, since that's what Minecraft expects.