### PR TITLE
Ender Tank Cell Fix & Feature Expansion

### DIFF
--- a/src/main/java/codechicken/enderstorage/storage/liquid/TileEnderTank.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/TileEnderTank.java
@@ -220,12 +220,12 @@ public class TileEnderTank extends TileFrequencyOwner implements IFluidHandler {
         ItemStack held = player.getCurrentEquippedItem();
         if (held == null) return false;
 
-        // Look for IFluidContainerItem (Large Fluid Cells / Flasks) - IFCI henceforth
+        // Look for IFluidContainerItem (Large Fluid Cells) - IFCI henceforth
         if (held.getItem() instanceof net.minecraftforge.fluids.IFluidContainerItem) {
             if (handleIFCI(player, held)) return true;
         }
 
-        // If no IFCI then regular Fluid Container logic (IC2 / GT cells / buckets) - FC henceforth
+        // If no IFCI then regular Fluid Container logic (IC2 / GT cells / buckets / flasks) - FC henceforth
         if (handleFCFullToEmpty(player, held)) return true;
         if (handleFCEmptyToFull(player, held)) return true;
 


### PR DESCRIPTION
### Changes:
- Makes Ender Tank use the proper amount of cells when putting into and taking out of tank
- Eliminates possibility of liquid being voided with cell glitches and running out of inventory space
- Will still complete operation and drop items now if inventory is full
- Allows Ender Tanks full compatibility with IC2 cell, GT cell, large fluid cells, flasks, buckets, etc. Across all sizes of full containers and in stacksizes larger than 1.
- Gives creative mode functionality as well to modify in-tank values without touching the inventory items. (I didn't include it in video example but just imagine it working exactly like the video except without modifying the inventory at all)

This will close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20774

If this is well received I will also port the IFCI cell functionality over to the BC tanks, they aren't currently working with them. 

I tried to put decent annotations for easier code review, also it's tested & working fine in latest daily.

### In-Game Before:

https://github.com/user-attachments/assets/f380e810-153f-4d3b-85de-8f7da75ed091

### In-Game After:

https://github.com/user-attachments/assets/8294423e-ec2d-45f6-b4b3-086b2c3bf5e9

