### PR TITLE
Disables Ender Tank From Operating As Cell

### DIFF
--- a/src/main/java/codechicken/enderstorage/common/ItemEnderStorage.java
+++ b/src/main/java/codechicken/enderstorage/common/ItemEnderStorage.java
@@ -57,6 +57,7 @@ public class ItemEnderStorage extends ItemBlock implements IFluidContainerItem {
         if (!getOwner(stack).equals("global")) list.add(getOwner(stack));
     }
 
+    // This function can be used in the functions down below to have ender tank be used as an IFCI, currently disabled.
     private EnderLiquidStorage getLiquidStorage(ItemStack stack) {
         return (EnderLiquidStorage) EnderStorageManager
                 .instance(FMLCommonHandler.instance().getEffectiveSide().isClient())
@@ -65,31 +66,21 @@ public class ItemEnderStorage extends ItemBlock implements IFluidContainerItem {
 
     @Override
     public FluidStack getFluid(ItemStack container) {
-        if (getMetadata(container.getItemDamage()) == 1) return getLiquidStorage(container).getFluid();
-
         return null;
     }
 
     @Override
     public int getCapacity(ItemStack container) {
-        if (getMetadata(container.getItemDamage()) == 1) return EnderLiquidStorage.CAPACITY;
-
         return 0;
     }
 
     @Override
     public int fill(ItemStack container, FluidStack resource, boolean doFill) {
-        if (getMetadata(container.getItemDamage()) == 1)
-            return getLiquidStorage(container).fill(null, resource, doFill);
-
         return 0;
     }
 
     @Override
     public FluidStack drain(ItemStack container, int maxDrain, boolean doDrain) {
-        if (getMetadata(container.getItemDamage()) == 1)
-            return getLiquidStorage(container).drain(null, maxDrain, doDrain);
-
         return null;
     }
 }


### PR DESCRIPTION
### Changes:
- Removes ability for ender tank to be treated as an IFluidContainerItem (behaving like a large fluid cell) 

### Why
- This works perfectly fine until you add another item to the stack, once that is done, because of the way IFCIs are written (and it would be unwise to rewrite them), once another item is added to the stack the transfer will multiply by that stacksize- and since all ender tanks of one variety are supposed to share one global inventory, this leads to duplication glitches
- I tried a bunch of cheeky solutions but the brass tax is that unless we want to make the stacksize of ender tanks limit to exactly one (which I think would be bad) our best route is to just let them function as physical items and not as cells. This should be inconsequential anyway, especially with my other recent change https://github.com/GTNewHorizons/EnderStorage/pull/20

This will close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20913