### PR TITLE
Fixed Vanilla EC removal not working

### DIFF
--- a/src/main/java/codechicken/enderstorage/EnderStorage.java
+++ b/src/main/java/codechicken/enderstorage/EnderStorage.java
@@ -25,6 +25,7 @@ import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerAboutToStartEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
@@ -96,6 +97,11 @@ public class EnderStorage {
         EnderStorageManager.registerPlugin(new EnderLiquidStoragePlugin());
 
         proxy.init();
+    }
+
+    @EventHandler
+    public void postInit(FMLPostInitializationEvent event) {
+        proxy.postInit();
     }
 
     private void loadPersonalItem() {

--- a/src/main/java/codechicken/enderstorage/EnderStorage.java
+++ b/src/main/java/codechicken/enderstorage/EnderStorage.java
@@ -64,12 +64,8 @@ public class EnderStorage {
         config = new ConfigFile(new File(CommonUtils.getMinecraftDir() + "/config", "EnderStorage.cfg")).setComment(
                 "EnderStorage Configuration File\nDeleting any element will restore it to it's default value\nBlock ID's will be automatically generated the first time it's run");
 
-        proxy.preInit();
-    }
-
-    @EventHandler
-    public void init(FMLInitializationEvent event) {
         loadPersonalItem();
+
         disableVanillaEnderChest = config.getTag("disable-vanilla")
                 .setComment("Set to true to make the vanilla enderchest unplaceable.").getBooleanValue(true);
         removeVanillaRecipe = config.getTag("disable-vanilla_recipe")
@@ -90,6 +86,12 @@ public class EnderStorage {
                 .getBooleanValue(false);
 
         EnderStorageManager.loadConfig(config);
+
+        proxy.preInit();
+    }
+
+    @EventHandler
+    public void init(FMLInitializationEvent event) {
         EnderStorageManager.registerPlugin(new EnderItemStoragePlugin());
         EnderStorageManager.registerPlugin(new EnderLiquidStoragePlugin());
 

--- a/src/main/java/codechicken/enderstorage/internal/EnderStorageProxy.java
+++ b/src/main/java/codechicken/enderstorage/internal/EnderStorageProxy.java
@@ -42,8 +42,9 @@ public class EnderStorageProxy {
         final TankSynchroniser tankSynchroniser = new TankSynchroniser();
         FMLCommonHandler.instance().bus().register(tankSynchroniser);
         MinecraftForge.EVENT_BUS.register(tankSynchroniser);
+    }
 
+    public void postInit() {
         if (disableVanillaEnderChest) EnderStorageRecipe.removeVanillaChest();
-
     }
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Quoting how I described the bug in [discord](https://discord.com/channels/181078474394566657/603348502637969419/1522446875767083030),

> There's a long-time bug in EnderStorage that has existed since ChickenBones, where the removal of the Vanilla Ender Chest recipe and block/item is performed *before* the config is loaded.
> The removal of the recipe is behind a config option `disable-vanilla_recipe` which is `false` by default, and the removal of the block/item is behind config option `disable-vanilla`. Both of these are stored on the `EnderStorage` class as uninitialized boolean fields.
> The config fields are initialized in `init` stage but the fields are accessed in `preInit`.

I was advised to move the initialization of config values to `preInit` stage and the recipe and block/item removal to `postInit` stage. I have done that; however, testing revealed another bug that occurs with default options:
<img width="691" height="548" alt="image" src="https://github.com/user-attachments/assets/9192cf82-d948-447e-a31c-5202cb67f4a5" />
...the default options being:
```properties
#Set to true to make the vanilla enderchest unplaceable.
disable-vanilla=true

#Set to true to make the vanilla enderchest uncraftable.
disable-vanilla_recipe=false
```
I [suggested](https://discord.com/channels/181078474394566657/603348502637969419/1523177280669618186) merging the two options into a single option that either *completely disables* or *completely enables* the Vanilla EC, but this could be destructive if players already have Vanilla ECs lying around in item form.

I decided to open the PR as a draft anyway for ease of access and discussion.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
