### PR TITLE
Use un-dyed tank and chest for NEI lookup

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:CodeChickenCore:1.4.10:dev")
+    api("com.github.GTNewHorizons:CodeChickenCore:1.4.16:dev")
 
-    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.48-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.114-GTNH:dev")
 }

--- a/src/main/java/codechicken/enderstorage/internal/NEIEnderStorageConfig.java
+++ b/src/main/java/codechicken/enderstorage/internal/NEIEnderStorageConfig.java
@@ -12,6 +12,7 @@ public class NEIEnderStorageConfig implements IConfigureNEI {
     @Override
     public void loadConfig() {
         if (EnderStorage.disableVanillaEnderChest) API.hideItem(new ItemStack(Blocks.ender_chest));
+        API.registerStackStringifyHandler(new StorageStackStringifyHandler());
     }
 
     @Override

--- a/src/main/java/codechicken/enderstorage/internal/StorageStackStringifyHandler.java
+++ b/src/main/java/codechicken/enderstorage/internal/StorageStackStringifyHandler.java
@@ -1,0 +1,26 @@
+package codechicken.enderstorage.internal;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import codechicken.enderstorage.EnderStorage;
+import codechicken.nei.api.IStackStringifyHandler;
+
+public class StorageStackStringifyHandler implements IStackStringifyHandler {
+
+    private final Item itemEnderStorage;
+
+    public StorageStackStringifyHandler() {
+        itemEnderStorage = Item.getItemFromBlock(EnderStorage.blockEnderChest);
+    }
+
+    // Use the un-dyed version for recipe/usage lookup
+    @Override
+    public ItemStack normalizeRecipeQueryStack(ItemStack stack) {
+        if (stack.getItem() == itemEnderStorage) {
+            boolean isTank = stack.getItemDamage() >> 12 == 1;
+            return new ItemStack(itemEnderStorage, stack.stackSize, isTank ? 1 << 12 : 0);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

The dye changes the meta value of the item which causes recipe lookup to not work when checking a chest or tank with a frequency set other than white/white/white. This PR makes it always use the white/white/white version.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24628 I think? I couldn't replicate the flashing tabs in the gif in the issue.


## Checklist
- [X] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
