### PR TITLE
Adds support for external dye tools

### DIFF
--- a/src/main/java/codechicken/enderstorage/api/EnderStorageDyeTool.java
+++ b/src/main/java/codechicken/enderstorage/api/EnderStorageDyeTool.java
@@ -1,0 +1,26 @@
+package codechicken.enderstorage.api;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Allows {@link net.minecraft.item.Item items} to register themselves as valid tools for dyeing a deployed ender chest
+ * or tank. Setting the frequency of an ender storage block through crafting, while using one of these tools, is not
+ * supported.
+ */
+public interface EnderStorageDyeTool {
+
+    /**
+     * Return the dye color that this tool is currently set to use.
+     *
+     * @return a dye index number. Return -1 if the tool does not provide dye.
+     */
+    int getDye(ItemStack itemStack);
+
+    /**
+     * This method will be called when the tool is being used, to allow the tool to expend a charge or consume power.
+     * <p>
+     * Defaults to nothing happening.
+     */
+    @SuppressWarnings("unused")
+    default void expendToolUse(ItemStack itemStack) {}
+}

--- a/src/main/java/codechicken/enderstorage/common/BlockEnderStorage.java
+++ b/src/main/java/codechicken/enderstorage/common/BlockEnderStorage.java
@@ -28,6 +28,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import codechicken.enderstorage.EnderStorage;
+import codechicken.enderstorage.api.EnderStorageDyeTool;
 import codechicken.enderstorage.api.EnderStorageManager;
 import codechicken.enderstorage.storage.item.TileEnderChest;
 import codechicken.enderstorage.storage.liquid.TileEnderTank;
@@ -152,7 +153,13 @@ public class BlockEnderStorage extends BlockContainer {
                 if (colours[hit.subHit - 1] == (~dye & 0xF)) return false;
                 colours[hit.subHit - 1] = ~dye & 0xF;
                 tile.setFreq(EnderStorageManager.getFreqFromColours(colours));
-                if (!player.capabilities.isCreativeMode) item.stackSize--;
+                if (!player.capabilities.isCreativeMode) {
+                    if (item.getItem() instanceof EnderStorageDyeTool) {
+                        ((EnderStorageDyeTool) item.getItem()).expendToolUse(item);
+                    } else {
+                        item.stackSize--;
+                    }
+                }
                 return true;
             }
         }

--- a/src/main/java/codechicken/enderstorage/common/EnderStorageRecipe.java
+++ b/src/main/java/codechicken/enderstorage/common/EnderStorageRecipe.java
@@ -17,6 +17,7 @@ import net.minecraftforge.oredict.RecipeSorter.Category;
 
 import codechicken.core.featurehack.GameDataManipulator;
 import codechicken.enderstorage.EnderStorage;
+import codechicken.enderstorage.api.EnderStorageDyeTool;
 import codechicken.enderstorage.api.EnderStorageManager;
 import codechicken.enderstorage.storage.item.ItemEnderChestDummy;
 import codechicken.lib.inventory.InventoryUtils;
@@ -181,6 +182,11 @@ public class EnderStorageRecipe implements IRecipe {
             for (ItemStack target : OreDictionary.getOres(oreDictionaryNames[i]))
                 if (OreDictionary.itemMatches(target, item, false)) return i;
         }
+
+        if (item.getItem() instanceof EnderStorageDyeTool) {
+            return ((EnderStorageDyeTool) item.getItem()).getDye(item);
+        }
+
         return -1;
     }
 


### PR DESCRIPTION
## Summary
This PR adds the ability for other mods to mark items as "dye tools" for the purposes of coloring ender tanks and chests that are deployed in-world. This allows for items like the GT5U spray cans to be used to color ender tanks and chests without consuming the entire item in one go. Using these dye tools for crafting is not supported with this PR.


## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
