### PR TITLE
partially fix ender tank perfs

### DIFF
--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -60,7 +60,6 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
     private static final int NUM_LISTS = 1 + 3 * 16 + 2 + 1;
 
     private static int displayListBase = -1;
-    private static final FloatBuffer pearlBuf = GLAllocation.createDirectFloatBuffer(16);
 
     private static final RenderCustomEndPortal renderEndPortal = new RenderCustomEndPortal(
             0.1205,
@@ -102,8 +101,12 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
     private static void ensureDisplayLists() {
         if (displayListBase != -1) return;
 
-        displayListBase = GL11.glGenLists(NUM_LISTS);
-        int next = displayListBase;
+        int base = GL11.glGenLists(NUM_LISTS);
+        if (base == 0) {
+            return;
+        }
+        displayListBase = base;
+        int next = base;
         next = compileModelList(next, tankModel, null);
         for (int i = 0; i < 3; i++) {
             for (int colour = 0; colour < 16; colour++) {
@@ -136,16 +139,6 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         GL11.glEnd();
         GL11.glEndList();
         return listId + 1;
-    }
-
-    private static void glMultMatrix(Matrix4 mat) {
-        pearlBuf.clear();
-        pearlBuf.put((float) mat.m00).put((float) mat.m10).put((float) mat.m20).put((float) mat.m30)
-                .put((float) mat.m01).put((float) mat.m11).put((float) mat.m21).put((float) mat.m31)
-                .put((float) mat.m02).put((float) mat.m12).put((float) mat.m22).put((float) mat.m32)
-                .put((float) mat.m03).put((float) mat.m13).put((float) mat.m23).put((float) mat.m33);
-        pearlBuf.flip();
-        GL11.glMultMatrix(pearlBuf);
     }
 
     @Override
@@ -192,6 +185,8 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         }
         GL11.glColor4f(1, 1, 1, 1);
 
+        if (displayListBase == -1) return;
+
         GL11.glEnable(GL11.GL_NORMALIZE);
         GL11.glPushMatrix();
         GL11.glTranslated(x + 0.5, y, z + 0.5);
@@ -224,7 +219,7 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
             GL11.glDisable(GL11.GL_LIGHTING);
             CCRenderState.changeTexture(HEDRON_TEXTURE);
             GL11.glPushMatrix();
-            glMultMatrix(pearlMat);
+            pearlMat.glApply();
             GL11.glCallList(displayListBase + LIST_HEDRON);
             GL11.glPopMatrix();
             GL11.glEnable(GL11.GL_LIGHTING);

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -1,8 +1,10 @@
 package codechicken.enderstorage.storage.liquid;
 
+import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.Map;
 
+import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
@@ -23,6 +25,7 @@ import codechicken.lib.render.CCModel;
 import codechicken.lib.render.CCModelLibrary;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.RenderUtils;
+import codechicken.lib.render.Vertex5;
 import codechicken.lib.render.uv.UVTranslation;
 import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
@@ -49,6 +52,15 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
     private static final Vector3 point = new Vector3(0, 0.4165, 0);
     private static final Matrix4 pearlMat = new Matrix4();
     private static final Cuboid6 liquidBounds = new Cuboid6(0, 0, 0, 0, 0, 0);
+
+    private static final int LIST_TANK = 0;
+    private static final int LIST_BUTTONS = 1;
+    private static final int LIST_VALVES = 1 + 3 * 16;
+    private static final int LIST_HEDRON = 1 + 3 * 16 + 2;
+    private static final int NUM_LISTS = 1 + 3 * 16 + 2 + 1;
+
+    private static int displayListBase = -1;
+    private static final FloatBuffer pearlBuf = GLAllocation.createDirectFloatBuffer(16);
 
     private static final RenderCustomEndPortal renderEndPortal = new RenderCustomEndPortal(
             0.1205,
@@ -85,6 +97,55 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         for (int colour = 0; colour < 16; colour++) {
             UVTranslationButtons[colour] = new UVTranslation(0.25 * (colour % 4), 0.25 * (colour / 4));
         }
+    }
+
+    private static void ensureDisplayLists() {
+        if (displayListBase != -1) return;
+
+        displayListBase = GL11.glGenLists(NUM_LISTS);
+        int next = displayListBase;
+        next = compileModelList(next, tankModel, null);
+        for (int i = 0; i < 3; i++) {
+            for (int colour = 0; colour < 16; colour++) {
+                next = compileModelList(next, buttons[i], UVTranslationButtons[colour]);
+            }
+        }
+        next = compileModelList(next, valveModel, UVTvalveOwned);
+        next = compileModelList(next, valveModel, UVTvalveNotOwned);
+        compileModelList(next, CCModelLibrary.icosahedron4, null);
+    }
+
+    private static int compileModelList(int listId, CCModel model, UVTranslation uvt) {
+        GL11.glNewList(listId, GL11.GL_COMPILE);
+        GL11.glBegin(model.vertexMode);
+        Vector3[] normals = model.normals();
+        for (int i = 0; i < model.verts.length; i++) {
+            Vertex5 v = model.verts[i];
+            if (normals != null && normals[i] != null) {
+                GL11.glNormal3f((float) normals[i].x, (float) normals[i].y, (float) normals[i].z);
+            }
+            double u = v.uv.u;
+            double vt = v.uv.v;
+            if (uvt != null) {
+                u += uvt.du;
+                vt += uvt.dv;
+            }
+            GL11.glTexCoord2f((float) u, (float) vt);
+            GL11.glVertex3f((float) v.vec.x, (float) v.vec.y, (float) v.vec.z);
+        }
+        GL11.glEnd();
+        GL11.glEndList();
+        return listId + 1;
+    }
+
+    private static void glMultMatrix(Matrix4 mat) {
+        pearlBuf.clear();
+        pearlBuf.put((float) mat.m00).put((float) mat.m10).put((float) mat.m20).put((float) mat.m30)
+                .put((float) mat.m01).put((float) mat.m11).put((float) mat.m21).put((float) mat.m31)
+                .put((float) mat.m02).put((float) mat.m12).put((float) mat.m22).put((float) mat.m32)
+                .put((float) mat.m03).put((float) mat.m13).put((float) mat.m23).put((float) mat.m33);
+        pearlBuf.flip();
+        GL11.glMultMatrix(pearlBuf);
     }
 
     @Override
@@ -124,6 +185,8 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
      */
     public static void renderTank(CCRenderState state, int rotation, float valve, int freq, boolean owned, double x,
             double y, double z, int offset, boolean renderFx) {
+        ensureDisplayLists();
+
         if (renderFx && !EnderStorage.disableFXTank) {
             renderEndPortal.renderAt(x, y, z);
         }
@@ -135,17 +198,13 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         GL11.glRotatef(-90 * (rotation + 2), 0, 1, 0);
 
         CCRenderState.changeTexture(ENDERTANK_TEXTURE);
-        state.startDrawingInstance(4);
-        tankModel.render();
-        state.drawInstance();
+        GL11.glCallList(displayListBase + LIST_TANK);
 
         CCRenderState.changeTexture(BUTTONS_TEXTURE);
-        state.startDrawingInstance(7);
         for (int i = 0; i < 3; i++) {
             int colour = EnderStorageManager.getColourFromFreq(freq, i);
-            buttons[i].render(UVTranslationButtons[colour]);
+            GL11.glCallList(displayListBase + LIST_BUTTONS + i * 16 + colour);
         }
-        state.drawInstance();
 
         if (valve >= 1E-5 || valve <= -1E-5) {
             GL11.glTranslated(point.x, point.y, point.z);
@@ -154,23 +213,20 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         }
 
         CCRenderState.changeTexture(ENDERTANK_TEXTURE);
-        state.startDrawingInstance(4);
-        valveModel.render(owned ? UVTvalveOwned : UVTvalveNotOwned);
-        state.drawInstance();
+        GL11.glCallList(displayListBase + LIST_VALVES + (owned ? 0 : 1));
         GL11.glPopMatrix();
         GL11.glDisable(GL11.GL_NORMALIZE);
 
         if (renderFx) {
             double time = ClientUtils.getRenderTime() + offset;
-            pearlMat.setIdentity()
-                    .translate(x + 0.5, y + 0.45 + EnderStorageClientProxy.getPearlBob(time) * 2, z + 0.5)
-                    .scale(0.04)
-                    .rotate(time / 3, Y);
+            pearlMat.setIdentity().translate(x + 0.5, y + 0.45 + EnderStorageClientProxy.getPearlBob(time) * 2, z + 0.5)
+                    .scale(0.04).rotate(time / 3, Y);
             GL11.glDisable(GL11.GL_LIGHTING);
             CCRenderState.changeTexture(HEDRON_TEXTURE);
-            state.startDrawingInstance(4);
-            CCModelLibrary.icosahedron4.render(pearlMat);
-            state.drawInstance();
+            GL11.glPushMatrix();
+            glMultMatrix(pearlMat);
+            GL11.glCallList(displayListBase + LIST_HEDRON);
+            GL11.glPopMatrix();
             GL11.glEnable(GL11.GL_LIGHTING);
         }
     }

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -26,7 +26,6 @@ import codechicken.lib.render.RenderUtils;
 import codechicken.lib.render.uv.UVTranslation;
 import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
-import codechicken.lib.vec.Rotation;
 import codechicken.lib.vec.SwapYZ;
 import codechicken.lib.vec.Transformation;
 import codechicken.lib.vec.Translation;
@@ -47,8 +46,9 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
     private static final UVTranslation UVTvalveOwned = new UVTranslation(0, 13 / 64D);
     private static final UVTranslation UVTvalveNotOwned = new UVTranslation(0, 0);
     private static final Vector3 Y = new Vector3(0, 1, 0);
-    private static final Vector3 Z = new Vector3(0, 0, 1);
     private static final Vector3 point = new Vector3(0, 0.4165, 0);
+    private static final Matrix4 pearlMat = new Matrix4();
+    private static final Cuboid6 liquidBounds = new Cuboid6(0, 0, 0, 0, 0, 0);
 
     private static final RenderCustomEndPortal renderEndPortal = new RenderCustomEndPortal(
             0.1205,
@@ -147,7 +147,11 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
         }
         state.drawInstance();
 
-        new Rotation(valve, Z).at(point).glApply();
+        if (valve >= 1E-5 || valve <= -1E-5) {
+            GL11.glTranslated(point.x, point.y, point.z);
+            GL11.glRotatef((float) (valve * MathHelper.todeg), 0, 0, 1);
+            GL11.glTranslated(-point.x, -point.y, -point.z);
+        }
 
         CCRenderState.changeTexture(ENDERTANK_TEXTURE);
         state.startDrawingInstance(4);
@@ -158,12 +162,10 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
 
         if (renderFx) {
             double time = ClientUtils.getRenderTime() + offset;
-            Matrix4 pearlMat = CCModelLibrary.getRenderMatrix(
-                    x + 0.5,
-                    y + 0.45 + EnderStorageClientProxy.getPearlBob(time) * 2,
-                    z + 0.5,
-                    new Rotation(time / 3, Y),
-                    0.04);
+            pearlMat.setIdentity()
+                    .translate(x + 0.5, y + 0.45 + EnderStorageClientProxy.getPearlBob(time) * 2, z + 0.5)
+                    .scale(0.04)
+                    .rotate(time / 3, Y);
             GL11.glDisable(GL11.GL_LIGHTING);
             CCRenderState.changeTexture(HEDRON_TEXTURE);
             state.startDrawingInstance(4);
@@ -174,9 +176,10 @@ public class EnderTankRenderer extends TileEntitySpecialRenderer {
     }
 
     public static void renderLiquid(FluidStack liquid, double x, double y, double z) {
+        liquidBounds.set(0.22 + x, 0.12 + y, 0.22 + z, 0.78 + x, 0.121 + 0.63 + y, 0.78 + z);
         RenderUtils.renderFluidCuboid(
                 liquid,
-                new Cuboid6(0.22 + x, 0.12 + y, 0.22 + z, 0.78 + x, 0.121 + 0.63 + y, 0.78 + z),
+                liquidBounds,
                 liquid.amount / ((double) EnderStorage.enderTankSize * FluidUtils.B),
                 0.75);
     }

--- a/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
+++ b/src/main/java/codechicken/enderstorage/storage/liquid/EnderTankRenderer.java
@@ -1,10 +1,8 @@
 package codechicken.enderstorage.storage.liquid;
 
-import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.Map;
 
-import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Reduce memory allocations and compile static models into display lists. Tested on daily 658.
Test setup:
<img width="1920" height="1017" alt="2026-08-06_02 18 42" src="https://github.com/user-attachments/assets/272b200c-4d4d-4c7c-bb41-5621fcd1e464" />

CPU sampling
before:
<img width="1188" height="471" alt="image" src="https://github.com/user-attachments/assets/495a9b21-49a4-4a78-8f2e-07077e4f3755" />

after:
<img width="1339" height="580" alt="image" src="https://github.com/user-attachments/assets/8b87d694-c35e-4ad9-bdfc-0eb5c5b0402e" />

As you can see, the big chunk is still here, but that is using FFP and it is out of my league.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
